### PR TITLE
appear.in has renamed to Whereby

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
           href="https://github.com/GoogleChrome/webrtc/tree/master/samples/web/content/apprtc">apprtc source</a>)<br>
           <a href="https://opentokrtc.com/">OpenTokRTC</a><br>
           <a href="https://talky.io/">Talky.io</a><br>
-          <a href="https://appear.in/">appear.in</a><br>
+          <a href="https://whereby.com/">Whereby (formerly appear.in)</a><br>
           <h4>File transfer sites:</h4>
           <!-- <a href="https://rtccopy.com/">RTCCopy.com</a> File transfer and
           chat using DataChannels<br> -->


### PR DESCRIPTION
More info: https://whereby.com/information/brand

Not sure if the (formerly) is needed at all. But there's still a lot of "x doesn't work on appear.in" and other text in places, so that's why I put it there. :)